### PR TITLE
Test i18n template rendering

### DIFF
--- a/ktor-features/ktor-thymeleaf/jvm/test-resources/templates/i18n_test.html
+++ b/ktor-features/ktor-thymeleaf/jvm/test-resources/templates/i18n_test.html
@@ -1,0 +1,1 @@
+<h1 th:text="#{hello_world}"></h1>

--- a/ktor-features/ktor-thymeleaf/jvm/test-resources/templates/i18n_test.properties
+++ b/ktor-features/ktor-thymeleaf/jvm/test-resources/templates/i18n_test.properties
@@ -1,0 +1,5 @@
+#
+# Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+#
+
+hello_world=Hello, world!

--- a/ktor-features/ktor-thymeleaf/jvm/test-resources/templates/i18n_test_es.properties
+++ b/ktor-features/ktor-thymeleaf/jvm/test-resources/templates/i18n_test_es.properties
@@ -1,0 +1,5 @@
+#
+# Copyright 2014-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+#
+
+hello_world=¡Hola, mundo!


### PR DESCRIPTION
Adds a test for template rendering when providing a locale.

By providing a Locale range to the Accept-Language header in the request, the server is able to construct an appropriate Locale to pass to the Thymeleaf context. The use of this Locale is then used to select the appropriate properties file to fill in the template.